### PR TITLE
Refactor BunCache to support custom paths and improve persistence han…

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,133 +1,175 @@
 import {
   describe,
   beforeEach,
-  setSystemTime,
   it,
   expect,
   afterAll,
+  afterEach,
+  setSystemTime,
 } from "bun:test";
-import { unlinkSync } from "node:fs";
+import { unlinkSync, existsSync } from "node:fs";
+import { join } from "node:path";
 
 import BunCache from ".";
 
-describe("Bun cache", () => {
+const TEST_DB_PATH = join(import.meta.dirname, "test-cache.sqlite");
+const CUSTOM_DB_PATH = join(import.meta.dirname, "custom-cache.db");
+
+// Helper to clean up test files
+const cleanupFiles = () => {
+  [TEST_DB_PATH, CUSTOM_DB_PATH, "cache.sqlite"].forEach((path) => {
+    if (existsSync(path)) {
+      unlinkSync(path);
+    }
+  });
+};
+
+afterAll(cleanupFiles);
+
+describe("BunCache (in-memory)", () => {
   let cache: BunCache;
 
   beforeEach(() => {
-    cache = new BunCache();
+    cache = new BunCache(); // default: non-persistent
+  });
+
+  afterEach(() => {
+    cache.clear?.(); // optional chaining in case API changes
   });
 
   it("should store and retrieve a string value", () => {
-    const key = "test-key";
-    const value = "test-value";
-    const ttl = 1000;
-
-    expect(cache.put(key, value, ttl)).toBe(true);
-    expect(cache.get(key)).toBe(value);
+    expect(cache.put("key", "hello")).toBe(true);
+    expect(cache.get("key")).toBe("hello");
   });
 
-  it("should store and retrieve an object value", () => {
-    const key = "test-key";
-    const value = { foo: "bar" };
-    const ttl = 1000;
-
-    expect(cache.put(key, value, ttl)).toBe(true);
-    expect(cache.get(key)).toEqual(value);
+  it("should store and retrieve an object", () => {
+    const obj = { name: "test", value: 42 };
+    expect(cache.put("obj", obj)).toBe(true);
+    expect(cache.get("obj")).toEqual(obj);
   });
 
-  it("should store and checks if that value exists", () => {
-    const key = "key-exists";
-    const value = { foo: "bar" };
-    const ttl = 1000;
-
-    expect(cache.put(key, value, ttl)).toBe(true);
-    expect(cache.hasKey(key)).toEqual(true);
+  it("should store null as distinguishable from absence", () => {
+    expect(cache.put("nullkey", null)).toBe(true);
+    expect(cache.get("nullkey")).toBe(null);
   });
 
-  it("should return null for a non-existent key", () => {
-    const key = "non-existent-key";
-
-    expect(cache.get(key)).toBeNull();
+  it("should store boolean true specially and retrieve it", () => {
+    expect(cache.put("truekey", true)).toBe(true);
+    expect(cache.get("truekey")).toBe(true);
   });
 
-  it("should return null for an expired key", () => {
-    const key = "test-key";
-    const value = "test-value";
-    const ttl = 100;
-
-    expect(cache.put(key, value, ttl)).toBe(true);
-    setSystemTime(new Date(Date.now() + ttl));
-    expect(cache.get(key)).toBeNull();
+  it("should return null for non-existent key", () => {
+    expect(cache.get("missing")).toBeNull();
   });
 
-  it("should store and retrieve a string value without ttl", () => {
-    const key = "test-key";
-    const value = "test-value";
+  it("should respect TTL and expire entries", () => {
+    cache.put("short", "data", 50);
+    expect(cache.get("short")).toBe("data");
+    expect(cache.hasKey("short")).toBe(true);
 
-    expect(cache.put(key, value)).toBe(true);
-    expect(cache.get(key)).toBe(value);
+    // Advance time
+    const mockDate = new Date(Date.now() + 100);
+    setSystemTime(mockDate);
+
+    expect(cache.get("short")).toBeNull();
+    expect(cache.hasKey("short")).toBe(false); // now respects expiration!
+  });
+
+  it("should keep entries without TTL forever", () => {
+    cache.put("forever", "persistent");
+    setSystemTime(new Date(Date.now() + 1_000_000));
+    expect(cache.get("forever")).toBe("persistent");
+    expect(cache.hasKey("forever")).toBe(true);
+  });
+
+  it("hasKey should return false for expired keys", () => {
+    cache.put("expiring", "temp", 10);
+    expect(cache.hasKey("expiring")).toBe(true);
+
+    setSystemTime(new Date(Date.now() + 100));
+    expect(cache.hasKey("expiring")).toBe(false);
+  });
+
+  it("should delete keys correctly", () => {
+    cache.put("todelete", "value");
+    expect(cache.delete("todelete")).toBe(true);
+    expect(cache.get("todelete")).toBeNull();
+    expect(cache.hasKey("todelete")).toBe(false);
   });
 });
 
-describe("Bun cache with persistance", () => {
+describe("BunCache (persistent - default path)", () => {
   let cache: BunCache;
 
   beforeEach(() => {
-    cache = new BunCache(true);
+    cleanupFiles(); // ensure clean start
+    cache = new BunCache({ persistent: true });
   });
 
-  afterAll(() => {
-    unlinkSync("cache.sqlite");
+  afterEach(() => {
+    cache.close();
   });
 
-  it("should store and retrieve a string value", () => {
-    const key = "test-key";
-    const value = "test-value";
-    const ttl = 1000;
+  it("should persist data across instances", () => {
+    cache.put("shared", { data: "important" }, 5000);
+    cache.close();
 
-    expect(cache.put(key, value, ttl)).toBe(true);
-    expect(cache.get(key)).toBe(value);
+    // New instance using same default path
+    const cache2 = new BunCache({ persistent: true });
+    expect(cache2.get("shared")).toEqual({ data: "important" });
+    cache2.close();
+  });
+});
+
+describe("BunCache (persistent - custom path)", () => {
+  let cache: BunCache;
+
+  beforeEach(() => {
+    cleanupFiles();
+    cache = new BunCache({ persistent: true, path: CUSTOM_DB_PATH });
   });
 
-  it("should store and retrieve an object value", () => {
-    const key = "test-key";
-    const value = { foo: "bar" };
-    const ttl = 1000;
-
-    expect(cache.put(key, value, ttl)).toBe(true);
-    expect(cache.get(key)).toEqual(value);
+  afterEach(() => {
+    cache.close();
   });
 
-  it("should store and checks if that value exists", () => {
-    const key = "key-exists";
-    const value = { foo: "bar" };
-    const ttl = 1000;
+  it("should create and load from custom path", () => {
+    expect(existsSync(CUSTOM_DB_PATH)).toBe(true);
 
-    expect(cache.put(key, value, ttl)).toBe(true);
-    expect(cache.hasKey(key)).toEqual(true);
+    cache.put("custom", "works");
+    cache.close();
+
+    const cache2 = new BunCache({ persistent: true, path: CUSTOM_DB_PATH });
+    expect(cache2.get("custom")).toBe("works");
+    cache2.close();
   });
 
-  it("should return null for a non-existent key", () => {
-    const key = "non-existent-key";
+  it("different paths should be isolated", () => {
+    cache.put("only-in-custom", "secret");
+    cache.close();
 
-    expect(cache.get(key)).toBeNull();
+    // This uses default path (cache.sqlite), not custom
+    const defaultCache = new BunCache({ persistent: true });
+    expect(defaultCache.get("only-in-custom")).toBeNull();
+    defaultCache.close();
+  });
+});
+
+describe("BunCache utility methods", () => {
+  it("clear() should remove all entries", () => {
+    const cache = new BunCache();
+    cache.put("a", 1);
+    cache.put("b", 2);
+    expect(cache.hasKey("a")).toBe(true);
+
+    cache.clear();
+
+    expect(cache.hasKey("a")).toBe(false);
+    expect(cache.hasKey("b")).toBe(false);
   });
 
-  it("should return null for an expired key", () => {
-    const key = "test-key";
-    const value = "test-value";
-    const ttl = 100;
-
-    expect(cache.put(key, value, ttl)).toBe(true);
-    setSystemTime(new Date(Date.now() + ttl));
-    expect(cache.get(key)).toBeNull();
-  });
-
-  it("should store and retrieve a string value without ttl", () => {
-    const key = "test-key";
-    const value = "test-value";
-
-    expect(cache.put(key, value)).toBe(true);
-    expect(cache.get(key)).toBe(value);
+  it("close() should be safe to call on in-memory cache", () => {
+    const cache = new BunCache();
+    expect(() => cache.close()).not.toThrow();
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,7 +34,7 @@ describe("BunCache (in-memory)", () => {
   });
 
   afterEach(() => {
-    cache.clear?.(); // optional chaining in case API changes
+    cache.clear();
   });
 
   it("should store and retrieve a string value", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,11 @@ class BunCache {
    * Only necessary for persistent caches or explicit cleanup in tests.
    */
   close(): void {
-    this.cache.close();
+    try {
+      this.cache.close();
+    } catch {
+      // Swallow errors during close to avoid crashes in cleanup paths.
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,11 @@ class BunCache {
    * Remove all entries from the cache.
    */
   clear(): void {
-    this.cache.run("DELETE FROM cache");
+    try {
+      this.cache.run("DELETE FROM cache");
+    } catch {
+      // Intentionally ignore errors to match error-handling style of put/delete.
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ class BunCache {
    * Stores a value in the cache.
    *
    * @param key   Cache key
-   * @param value Value to store (string, object, null, boolean)
+   * @param value Value to store (string, number, object, null, boolean)
    * @param ttl   Time-to-live in milliseconds (optional)
    */
   put(key: string, value: string | number | object | boolean | null, ttl?: number): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,116 +1,191 @@
 import { Database } from "bun:sqlite";
 
 /**
- * A class representing a cache using Bun's SQLite.
+ * Options for configuring the BunCache instance.
+ * - `persistent`: when true, the cache is stored on disk in a SQLite file.
+ * - `path`: custom file path for the SQLite DB (only used when `persistent` is true).
+ */
+interface BunCacheOptions {
+  persistent?: boolean;
+  path?: string;
+}
+
+/**
+ * Row schema used internally for the SQLite table.
+ */
+interface CacheSchema {
+  key: string;
+  value: string | null;
+  ttl: number | null;
+}
+
+/**
+ * BunCache — a tiny cache backed by Bun's `bun:sqlite`.
+ *
+ * Key behaviors and notes:
+ * - Values that are `string` or serializable `object` are stored as JSON text.
+ * - `true` (boolean) and `null` are stored as SQL `NULL` in the underlying table.
+ *   When a row's `value` is `NULL` it will be returned as `true` by `get()`.
+ *   (This is an implementation detail — read the examples below to see how
+ *   different inputs are returned.)
+ * - `ttl` is stored as an absolute epoch ms timestamp. A `null` TTL means
+ *   the value does not expire.
+ *
+ * Example:
+ * const cache = new BunCache();
+ * cache.put('a', 'hello');
+ * cache.put('b', { x: 1 }, 1000); // expires in 1s
+ * cache.put('c', true); // stored as NULL in DB and read back as true
  */
 class BunCache {
   private cache: Database;
+  constructor(options: BunCacheOptions = {}) {
+    const { persistent = false, path } = options;
 
-  /**
-   * Creates a new instance of the BunCache class.
-   */
-  constructor(persistance: boolean = false) {
-    this.cache = new Database(persistance ? "cache.sqlite" : ":memory:");
+    if (persistent) {
+      const dbPath = path ?? "cache.sqlite";
+      this.cache = new Database(dbPath, { create: true });
+    } else {
+      this.cache = new Database(":memory:");
+    }
+
     this.initializeSchema();
   }
 
   /**
-   * Initializes the cache schema.
+   * Creates the cache table if it doesn't exist.
    */
   private initializeSchema() {
     this.cache.run(`
       CREATE TABLE IF NOT EXISTS cache (
         key TEXT PRIMARY KEY,
         value TEXT,
-        ttl INTEGER,
-        UNIQUE(key)
+        ttl INTEGER
       );
     `);
   }
 
   /**
-   * Retrieves the value associated with a key from the cache.
-   * @param key - The key for which to fetch the value.
-   * @returns The value if the key exists and hasn't expired, `null` otherwise.
+   * Retrieve a value from the cache.
+   * - Returns `null` if the key is missing or expired.
+   * - If the stored DB `value` is `NULL`, this method returns `true`.
+   * - Strings and JSON-serializable objects are parsed back to their original types.
    */
   get(key: string): string | object | boolean | null {
-    const query = this.cache.prepare(
-      "SELECT value, ttl FROM cache WHERE key = ?",
-    );
-    const result = query.get(key) as CacheSchema | null;
-    if (!result) return null;
+    const query = this.cache.prepare("SELECT value, ttl FROM cache WHERE key = ?");
+    const row = query.get(key) as CacheSchema | undefined;
 
-    if (result.value === null) return true;
+    if (!row) return null;
 
-    const currentTime = Date.now();
+    const now = Date.now();
 
-    if (result.ttl === null || result.ttl > currentTime) {
-      try {
-        return JSON.parse(result.value);
-      } catch (error) {
-        return result.value;
-      }
+    // Expired?
+    if (row.ttl !== null && row.ttl <= now) {
+      this.delete(key); // clean up
+      return null;
     }
 
-    this.delete(key);
-    return null;
+    if (row.value === null) {
+      return null; // actual null
+    }
+
+    if (row.value === "__TRUE__") {
+      return true;
+    }
+
+    try {
+      return JSON.parse(row.value);
+    } catch {
+      return row.value; // fallback
+    }
   }
 
   /**
-   * Adds a value to the cache.
-   * @param key - The key under which to store the value.
-   * @param value - The value to be stored.
-   * @param ttl - The time-to-live for the value, in milliseconds.
-   * @returns `true` if the value was successfully stored, `false` otherwise.
+   * Stores a value in the cache.
+   *
+   * @param key   Cache key
+   * @param value Value to store (string, object, null, boolean)
+   * @param ttl   Time-to-live in milliseconds (optional)
    */
-  put(key: string, value: string | object | null, ttl?: number): boolean {
-    const expirationTime = typeof ttl === "undefined" ? null : Date.now() + ttl;
+  put(key: string, value: string | number | object | boolean | null, ttl?: number): boolean {
+    let serialized: string | null;
+    let isTrueFlag = false;
+
+    if (value === true) {
+      serialized = null;
+      isTrueFlag = true;
+    } else if (value === null) {
+      serialized = null;
+      isTrueFlag = false;
+    } else {
+      serialized = JSON.stringify(value);
+    }
+
+    const expiration = ttl !== undefined ? Date.now() + ttl : null;
 
     try {
-      this.cache.run("INSERT OR REPLACE INTO cache VALUES (?, ?, ?)", [
-        key,
-        value ? JSON.stringify(value) : null,
-        expirationTime,
-      ]);
+      // We need to store both the value and a flag for true/null ambiguity
+      // But we only have 3 columns. So: use a special sentinel string for true
+      this.cache.run(
+        "INSERT OR REPLACE INTO cache (key, value, ttl) VALUES (?, ?, ?)",
+        [
+          key,
+          serialized ?? (isTrueFlag ? "__TRUE__" : null),
+          expiration,
+        ],
+      );
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }
 
   /**
-   * Removes a key from the cache.
-   * @param key - The key to be deleted.
-   * @returns `true` if the key was successfully deleted, `false` otherwise.
+   * Remove a key from the cache.
    */
   delete(key: string): boolean {
     try {
       this.cache.run("DELETE FROM cache WHERE key = ?", [key]);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }
 
   /**
-   * Checks if a key exists in the cache.
-   * @param key - The key to be checked
-   * @returns `true` if the key exists, `false` otherwise
+   * Check whether a key exists and hasn't expired.
    */
   hasKey(key: string): boolean {
-    try {
-      const query = this.cache.prepare("SELECT * FROM cache WHERE key = ?");
-      return (query.get(key) as CacheSchema | null) !== null;
-    } catch (error) {
+    const query = this.cache.prepare(
+      "SELECT ttl FROM cache WHERE key = ?",
+    );
+    const row = query.get(key) as { ttl: number | null } | undefined;
+
+    if (!row) return false;
+
+    if (row.ttl !== null && row.ttl <= Date.now()) {
+      this.delete(key);
       return false;
     }
+
+    return true;
+  }
+
+  /**
+   * Remove all entries from the cache.
+   */
+  clear(): void {
+    this.cache.run("DELETE FROM cache");
+  }
+
+  /**
+   * Close the underlying SQLite database connection.
+   * Only necessary for persistent caches or explicit cleanup in tests.
+   */
+  close(): void {
+    this.cache.close();
   }
 }
 
 export default BunCache;
-
-export interface CacheSchema {
-  key: string;
-  value: string | null;
-  ttl: number | null;
-}
+export type { BunCacheOptions, CacheSchema };


### PR DESCRIPTION
# PR: Add Custom Path Support & Fix Critical Bugs in BunCache

## Summary

This PR improves `BunCache` with:

- Custom SQLite file path when persistent (`{ persistent: true, path: string }`)
- Options-based constructor (replaces old boolean flag)
- Added `clear()` and `close()` methods

## Bug Fixes

- Fixed: Storing `null` returned `true` on get (ambiguous SQL NULL)
- Fixed: `hasKey()` returned `true` for expired/deleted entries
- Expired rows now cleaned up on access
- `clear()` and `delete()` now properly reflected in `hasKey()`

## Other Improvements

- Cleaner schema (removed redundant `UNIQUE(key)`)
- Used `"__TRUE__"` sentinel to safely distinguish `true` vs `null`

## Tests

- Rewrote and expanded test suite
- Covers in-memory, persistent (default + custom path), TTL, null/true handling, cleanup
- All tests now pass

Ready for review!